### PR TITLE
Update writer.inc.php

### DIFF
--- a/inc/writer.inc.php
+++ b/inc/writer.inc.php
@@ -81,7 +81,7 @@ class SB_WriterInterface extends SB_Converter
         $this->loader = $loader;
     }
 
-    function settingItems()
+    public static function settingItems()
     {
         static $values = array
         (


### PR DESCRIPTION
writer.inc.php >> line 84 >>     public static function settingItems()
line 100 >>     public static function settingsValueFmt($label, $att)
line 113 >>     public static function settingsValue($label)
--> this corrects a problem when calling 

main menue → Sitebar parameters → export properties

Attention: Non-static method SB_WriterInterface::settingItems() should not be called statically, assuming $this from incompatible context [command.php line 2788]
Attention: Non-static method SB_WriterInterface::settingsValue() should not be called statically, assuming $this from incompatible context [command.php line 2790]
Attention: Non-static method SB_WriterInterface::settingsValue() should not be called statically, assuming $this from incompatible context [command.php line 2790]
